### PR TITLE
fix: delete bidirectional mapping

### DIFF
--- a/src/main/java/org/payw/npoem/domain/entry/Word.java
+++ b/src/main/java/org/payw/npoem/domain/entry/Word.java
@@ -21,9 +21,6 @@ public class Word extends BaseTimeEntity {
     @Column(nullable = false, unique = true)
     private String text;
 
-    @OneToMany(mappedBy = "word")
-    private List<Poem> poems;
-
     @Builder
     public Word(String text) {
         this.text = text;


### PR DESCRIPTION
- Poem 과 Word 엔터티의 양방향 매핑 제거
- Poem - > Word로의 단방향 매핑